### PR TITLE
Added interactive tooltip markers and heatmap + tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,11 @@ app = Flask(__name__)
 
 @app.route('/')
 def plot_folium_map():
-    map = get_folium_map()
+    # sample alerts
+    alert_coords = [[47.663082, -122.310859], [47.658377, -122.317777]]
+    alert_messages = ["Police looking for man with handgun on 47th St. near 16th Ave. Secure doors, avoid area if possible.",
+                      "Shooting reported near 42nd Ave NE/Roosevelt at 12:46pm. Shooter fled in white vehicle."]
+    map = get_folium_map(alert_coords, alert_messages)
     return render_template('/base.html', map_html=map)
 
 if __name__ == '__main__':

--- a/tests/test_visualization_manager.py
+++ b/tests/test_visualization_manager.py
@@ -5,6 +5,7 @@ import unittest
 import geopandas as gpd
 import numpy as np
 from visualization_manager.visualization_manager import filter_geodf
+from visualization_manager.visualization_manager import get_folium_map
 
 # Smoke test
 class TestFilterGeoDF(unittest.TestCase):
@@ -89,6 +90,77 @@ class TestFilterGeoDF(unittest.TestCase):
         for point in test_cases:
             with self.assertRaises(ValueError):
                 filter_geodf(gdf, lat=point[0], lon=point[1])
+
+class TestGetFoliumMap(unittest.TestCase):
+    """
+    Tests methods for get_folium_map function
+    in visualization_manager.py
+    """
+    # Smoke tests
+    def test_smoke(self):
+        """
+        Smoke test for get_folium_map
+        """
+        alert_coords = [[47.663082, -122.310859], [47.658377, -122.317777]]
+        alert_messages = ["Police looking for man with handgun on 47th St. near 16th Ave. Secure doors, avoid area if possible.",
+                        "Shooting reported near 42nd Ave NE/Roosevelt at 12:46pm. Shooter fled in white vehicle."]
+        map = get_folium_map(alert_coords, alert_messages)
+        self.assertTrue(True)
+
+    # TODO: Make one-shot tests
+
+    # Edge case tests
+    def test_alert_coords_type(self):
+        """
+        Edge case test to check that alert_coords is a list
+        """
+        test_cases = ["String", {}, np.array([3, 2, 2]), 34]
+        alert_messages = ["One", "Two"]
+        for test in test_cases:
+            with self.assertRaises(ValueError):
+                get_folium_map(test, alert_messages)
+
+    def test_alert_coords_type(self):
+        """
+        Edge case test to check that the coords in alert_coords are numbers
+        """
+        test_cases = ["String", {}, np.array([3, 2, 2])]
+        alert_messages = ["One", "Two"]
+        for test in test_cases:
+            alert_coords = [[test, -122.310859], [47.658377, -122.317777]]
+            with self.assertRaises(ValueError):
+                get_folium_map(alert_coords, alert_messages)
+
+    def test_alert_messages_type(self):
+        """
+        Edge case test to check that alert_messages is a list
+        """
+        alert_coords = [[47.663082, -122.310859], [47.658377, -122.317777]]
+        test_cases = ["String", {}, np.array([3, 2, 2]), 34]
+        for test in test_cases:
+            with self.assertRaises(ValueError):
+                get_folium_map(alert_coords, test)
+    
+    def test_alert_messages_length(self):
+        """
+        Edge case test to check that alert_messages is a list
+        """
+        alert_coords = [[47.663082, -122.310859], [47.658377, -122.317777]]
+        test_cases = [["One"], ["One", "Two", "Three"]]
+        for test in test_cases:
+            with self.assertRaises(ValueError):
+                get_folium_map(alert_coords, test)
+
+    def test_alert_messages_element_type(self):
+        """
+        Edge case test to check that the elements in alert_messages are strings
+        """
+        alert_coords = [[47.663082, -122.310859]]
+        test_cases = [{}, np.array([3, 2, 2]), 34]
+        for test in test_cases:
+            with self.assertRaises(ValueError):
+                get_folium_map(alert_coords, [test])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/visualization_manager/visualization_manager.py
+++ b/visualization_manager/visualization_manager.py
@@ -122,5 +122,15 @@ def get_folium_map():
         line_color='red'
     ).add_to(map)
 
+    ## TODO: James will work on displaying markers
+    folium.CircleMarker(
+        [47.663082, -122.310859],
+        popup="<b>Police looking for man with handgun on 47th St. near 16th Ave. Secure doors, avoid area if possible.</b>"
+    ).add_to(map)
+    folium.CircleMarker(
+        [47.658363, -122.317714],
+        popup="<b>Shooting reported near 42nd Ave NE/Roosevelt at 12:46pm. Shooter fled in white vehicle.</b>",
+    ).add_to(map)
+
     m_html = map.get_root().render()
     return m_html

--- a/visualization_manager/visualization_manager.py
+++ b/visualization_manager/visualization_manager.py
@@ -17,6 +17,7 @@ outputs:
 
 import pyproj
 import folium
+from folium.plugins import HeatMap
 import geopandas as gpd
 from shapely.geometry import Point
 from shapely.ops import nearest_points, transform
@@ -93,19 +94,39 @@ def filter_geodf(gdf, lat, lon, max_distance=10):
 
     return gdf
 
-def get_folium_map():
-    """_summary_
+def get_folium_map(alert_coords, alert_messages):
+    """
+    Given information about alerts, return a rendered html leaflet map of the U-district area.
 
     Parameters
     ----------
-    gdf : _type_
-        _description_
-
+    alert_coords : List of List containing two Floats
+        A list of coordinates [lat, long]
+        representing alert locations
+    alert_messages : List of Str
+        Must be the same length as alert_coords
+        A list of alert descriptions corresponding to alert_coords
+        
     Returns
     -------
     m_html : str
-        
+        A rendered html leaflet map to display on the web application.
     """
+
+    # alert_coords exceptions
+    for alert in alert_coords:
+        if not isinstance(alert, list) or len(alert) != 2:
+            raise ValueError("alert_coords must contain Lists of length 2")
+        if not isinstance(alert[0], (int, float)) or not isinstance(alert[1], (int, float)):
+            raise ValueError("coordinates in alert_coords must contain numbers")
+        
+    # alert_messages exceptions
+    if not isinstance(alert_messages, list) or len(alert_messages) != len(alert_coords):
+        raise ValueError("alert_messages must be a list with the same length as alert_coords")
+    if any([True for alert in alert_messages if not isinstance(alert, str)]):
+        raise ValueError("alert_messages must only contain strings")
+
+    # Display the U-District area
     gdf = gpd.read_file('../data/SeattleGISData/udistrict_streets.geojson')
     # pylint: disable=line-too-long
     mapbox_api_key = 'pk.eyJ1IjoiZXZhbnlpcCIsImEiOiJjbGRxYnc3dXEwNWxxM25vNjRocHlsOHFyIn0.0H4RiKd8X94CeoXwEd4TgQ'
@@ -116,21 +137,33 @@ def get_folium_map():
                     zoom_start=15, 
                     tiles = tile, 
                     attr="Maptiler Dark")
-    folium.Choropleth(
-        geo_data=gdf,
-        line_weight=2,
-        line_color='red'
-    ).add_to(map)
+    # Highlight the streets in U-District
+    # folium.Choropleth(
+    #     geo_data=gdf,
+    #     line_weight=2,
+    #     line_color='red'
+    # ).add_to(map)
 
-    ## TODO: James will work on displaying markers
-    folium.CircleMarker(
-        [47.663082, -122.310859],
-        popup="<b>Police looking for man with handgun on 47th St. near 16th Ave. Secure doors, avoid area if possible.</b>"
-    ).add_to(map)
-    folium.CircleMarker(
-        [47.658363, -122.317714],
-        popup="<b>Shooting reported near 42nd Ave NE/Roosevelt at 12:46pm. Shooter fled in white vehicle.</b>",
-    ).add_to(map)
+    ## TODO: Implement different coloring based on the urgency of an alert
+    for i in range(len(alert_coords)):
+        # Display streets that are close to the alert
+        filtered_streets = filter_geodf(gdf, alert_coords[i][0], alert_coords[i][1])
+        folium.Choropleth(
+            geo_data=filtered_streets,
+            line_weight=3,
+            line_color='blue'
+        ).add_to(map)
+
+        # Set a marker with an interactive popup
+        iframe = folium.IFrame("<b>" + alert_messages[i] + "</b>")
+        popup = folium.Popup(iframe, min_width=300, max_width=300)
+        folium.Marker(
+            alert_coords[i],
+            popup=popup
+        ).add_to(map)
+    
+    # Create a heatmap layer for each alert
+    HeatMap(alert_coords, radius=10, gradient = {0: 'blue', 0: 'lime', 0.5: 'red'}).add_to(map)
 
     m_html = map.get_root().render()
     return m_html


### PR DESCRIPTION
get_folium_map now takes in two arguments:
- alert_coords: the coordinates [lat, long] of alerts
- alert_messages: the UW alert description

Tests created for the get_folium_map function in tests\test_visualization_manager.py
There is an error where udistrict_streets.geojson cannot be found if app.py is run from the root directory. Can we change sys.path to make the file reference robust instead of relative to the run location?